### PR TITLE
Francedata: use end_date when available

### DIFF
--- a/representatives/contrib/francedata/import_representatives.py
+++ b/representatives/contrib/francedata/import_representatives.py
@@ -25,7 +25,10 @@ representative_pre_import = django.dispatch.Signal(
 
 def _get_mdef_item(mdef, item, json, default=None):
     if item in mdef:
-        return mdef[item] % json
+        try:
+            return mdef[item] % json
+        except:
+            return default
 
     if '%s_path' % item in mdef:
         return _get_path(json, mdef['%s_path' % item])

--- a/representatives/contrib/francedata/tests/representatives_expected.json
+++ b/representatives/contrib/francedata/tests/representatives_expected.json
@@ -557,6 +557,7 @@
         "representative": 2,
         "link": "",
         "begin_date": "2004-09-26",
+        "end_date": "2012-01-01",
         "constituency": 2
     },
     "model": "representatives.mandate",
@@ -570,6 +571,7 @@
         "representative": 2,
         "link": "",
         "begin_date": "2004-09-26",
+        "end_date": "2012-01-01",
         "constituency": 2
     },
     "model": "representatives.mandate",
@@ -583,6 +585,7 @@
         "representative": 2,
         "link": "",
         "begin_date": "2004-09-26",
+        "end_date": "2012-01-01",
         "constituency": 2
     },
     "model": "representatives.mandate",
@@ -596,6 +599,7 @@
         "representative": 2,
         "link": "",
         "begin_date": "2004-09-26",
+        "end_date": "2012-01-01",
         "constituency": 2
     },
     "model": "representatives.mandate",
@@ -609,6 +613,7 @@
         "representative": 2,
         "link": "",
         "begin_date": "2004-09-26",
+        "end_date": "2012-01-01",
         "constituency": 2
     },
     "model": "representatives.mandate",
@@ -622,6 +627,7 @@
         "representative": 2,
         "link": "",
         "begin_date": "2004-09-26",
+        "end_date": "2012-01-01",
         "constituency": 2
     },
     "model": "representatives.mandate",

--- a/representatives/contrib/francedata/tests/representatives_input.json
+++ b/representatives/contrib/francedata/tests/representatives_input.json
@@ -184,6 +184,7 @@
   },
   {
     "mandat_debut": "2004-09-26",
+    "mandat_fin": "2012-01-01",
     "twitter": "dassouline",
     "profession": "Professeur d'histoire-géographie",
     "url_nossenateurs_api": "http://www.nossenateurs.fr/david-assouline/json",

--- a/representatives/contrib/francedata/variants.py
+++ b/representatives/contrib/francedata/variants.py
@@ -15,6 +15,7 @@ class DelegationHelper:
     def __call__(self, data):
         items = []
         start = data['mandat_debut']
+        end = data.get('mandat_fin', None)
 
         if self.committees:
             gdata = (i['responsabilite'] for i in data['responsabilites'])
@@ -32,12 +33,17 @@ class DelegationHelper:
             if orga in self.equivs:
                 orga = self.equivs[orga]
 
-            items.append({
+            item = {
                 'abbr': self.abbrevs[orga] if orga in self.abbrevs else '',
                 'name': orga,
                 'role': role,
                 'start': start
-            })
+            }
+
+            if end:
+                item['end'] = end
+
+            items.append(item)
 
         return items
 
@@ -139,7 +145,8 @@ FranceDataVariants = {
                 "abbr": "AN",
                 "name": u"Assemblée nationale",
                 "role": u"Député",
-                "start": "%(mandat_debut)s"
+                "start": "%(mandat_debut)s",
+                "end": "%(mandat_fin)s"
             },
             {
                 "kind": "group",
@@ -147,19 +154,22 @@ FranceDataVariants = {
                 "abbr": "%(groupe_sigle)s",
                 "name_path": "groupe/organisme",
                 "role_path": "groupe/fonction",
-                "start": "%(mandat_debut)s"
+                "start": "%(mandat_debut)s",
+                "end": "%(mandat_fin)s"
             },
             {
                 "kind": "department",
                 "abbr": "%(num_deptmt)s",
                 "name": "%(nom_circo)s",
-                "start": "%(mandat_debut)s"
+                "start": "%(mandat_debut)s",
+                "end": "%(mandat_fin)s"
             },
             {
                 "kind": "district",
                 "abbr": "%(num_deptmt)s-%(num_circo)s",
                 "name_fn": _get_rep_district_name,
-                "start": "%(mandat_debut)s"
+                "start": "%(mandat_debut)s",
+                "end": "%(mandat_fin)s"
             },
             {
                 "kind": "committee",
@@ -168,7 +178,8 @@ FranceDataVariants = {
                 "abbr": "%(abbr)s",
                 "name": "%(name)s",
                 "role": "%(role)s",
-                "start": "%(start)s"
+                "start": "%(start)s",
+                "end": "%(end)s"
             },
             {
                 "kind": "delegation",
@@ -177,7 +188,8 @@ FranceDataVariants = {
                 "abbr": "%(abbr)s",
                 "name": "%(name)s",
                 "role": "%(role)s",
-                "start": "%(start)s"
+                "start": "%(start)s",
+                "end": "%(end)s"
             }
         ]
     },
@@ -199,7 +211,8 @@ FranceDataVariants = {
                 "abbr": "SEN",
                 "name": u"Sénat",
                 "role": u"Sénateur",
-                "start": "%(mandat_debut)s"
+                "start": "%(mandat_debut)s",
+                "end": "%(mandat_fin)s"
             },
             {
                 "kind": "group",
@@ -207,19 +220,22 @@ FranceDataVariants = {
                 "abbr": "%(groupe_sigle)s",
                 "name_path": "groupe/organisme",
                 "role_path": "groupe/fonction",
-                "start": "%(mandat_debut)s"
+                "start": "%(mandat_debut)s",
+                "end": "%(mandat_fin)s"
             },
             {
                 "kind": "department",
                 "abbr": "%(num_deptmt)s",
                 "name": "%(nom_circo)s",
-                "start": "%(mandat_debut)s"
+                "start": "%(mandat_debut)s",
+                "end": "%(mandat_fin)s"
             },
             {
                 "kind": "district",
                 "abbr": "%(num_deptmt)s-%(num_circo)s",
                 "name_fn": _get_rep_district_name,
-                "start": "%(mandat_debut)s"
+                "start": "%(mandat_debut)s",
+                "end": "%(mandat_fin)s"
             },
             {
                 "kind": "committee",
@@ -228,7 +244,8 @@ FranceDataVariants = {
                 "abbr": "%(abbr)s",
                 "name": "%(name)s",
                 "role": "%(role)s",
-                "start": "%(start)s"
+                "start": "%(start)s",
+                "end": "%(end)s"
             },
             {
                 "kind": "delegation",
@@ -237,7 +254,8 @@ FranceDataVariants = {
                 "abbr": "%(abbr)s",
                 "name": "%(name)s",
                 "role": "%(role)s",
-                "start": "%(start)s"
+                "start": "%(start)s",
+                "end": "%(end)s"
             }
         ]
     }


### PR DESCRIPTION
This patch parses end_date when it's available. This enables distinguishing former representatives (non active reps are not visible by default in memopol).